### PR TITLE
Issue/12 mcp 툴 구현 및 시멘틱 서치로 변경 

### DIFF
--- a/aladin-mcp-server/README.md
+++ b/aladin-mcp-server/README.md
@@ -1,3 +1,15 @@
 # aladin mcp server
 
 node v22 이상
+
+## 실행
+```bash
+pnpm install
+
+# local 실행
+pnpm run dev
+```
+- mcp 서버 테스트
+```bash
+npx @modelcontextprotocol/inspector # 연결 url 은 http://localhost:3000/mcp
+```

--- a/aladin-mcp-server/package.json
+++ b/aladin-mcp-server/package.json
@@ -19,6 +19,7 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "pg": "^8.16.0",
+    "pgvector": "^0.2.1",
     "zod": "^3.25.56"
   },
   "devDependencies": {

--- a/aladin-mcp-server/package.json
+++ b/aladin-mcp-server/package.json
@@ -19,7 +19,6 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "pg": "^8.16.0",
-    "pgvector": "^0.2.1",
     "zod": "^3.25.56"
   },
   "devDependencies": {

--- a/aladin-mcp-server/package.json
+++ b/aladin-mcp-server/package.json
@@ -15,7 +15,7 @@
   "packageManager": "pnpm@10.11.0",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "aladin-client": "^1.0.3",
+    "aladin-client": "^1.0.4",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "pg": "^8.16.0",

--- a/aladin-mcp-server/pnpm-lock.yaml
+++ b/aladin-mcp-server/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       pg:
         specifier: ^8.16.0
         version: 8.16.0
+      pgvector:
+        specifier: ^0.2.1
+        version: 0.2.1
       zod:
         specifier: ^3.25.56
         version: 3.25.56
@@ -921,6 +924,10 @@ packages:
 
   pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
+  pgvector@0.2.1:
+    resolution: {integrity: sha512-nKaQY9wtuiidwLMdVIce1O3kL0d+FxrigCVzsShnoqzOSaWWWOvuctb/sYwlai5cTwwzRSNa+a/NtN2kVZGNJw==}
+    engines: {node: '>= 18'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2015,6 +2022,8 @@ snapshots:
   pgpass@1.0.5:
     dependencies:
       split2: 4.2.0
+
+  pgvector@0.2.1: {}
 
   picocolors@1.1.1: {}
 

--- a/aladin-mcp-server/pnpm-lock.yaml
+++ b/aladin-mcp-server/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.12.1
         version: 1.12.1
       aladin-client:
-        specifier: ^1.0.3
-        version: 1.0.3
+        specifier: ^1.0.4
+        version: 1.0.4
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
@@ -438,8 +438,8 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
-  aladin-client@1.0.3:
-    resolution: {integrity: sha512-lXrz4LAEWe6d8ls7ZPP3vhDm7XX83yTKAnfv5i/HV+ZGiure85xYJwXxGVIzdmdbDi4q208GDZ06f9S7olvd8w==}
+  aladin-client@1.0.4:
+    resolution: {integrity: sha512-zZG8pp+xFpLc6lKwnsqsL/ISrb6idrW8XvZ2ZbukBER0rqfLQFUXHbrrIxBBwi12aXLy/VdG24mmLRjqfyDkKA==}
     engines: {node: '>=18.0.0'}
 
   ansi-regex@5.0.1:
@@ -1539,7 +1539,7 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  aladin-client@1.0.3: {}
+  aladin-client@1.0.4: {}
 
   ansi-regex@5.0.1: {}
 

--- a/aladin-mcp-server/pnpm-lock.yaml
+++ b/aladin-mcp-server/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       pg:
         specifier: ^8.16.0
         version: 8.16.0
-      pgvector:
-        specifier: ^0.2.1
-        version: 0.2.1
       zod:
         specifier: ^3.25.56
         version: 3.25.56
@@ -924,10 +921,6 @@ packages:
 
   pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
-
-  pgvector@0.2.1:
-    resolution: {integrity: sha512-nKaQY9wtuiidwLMdVIce1O3kL0d+FxrigCVzsShnoqzOSaWWWOvuctb/sYwlai5cTwwzRSNa+a/NtN2kVZGNJw==}
-    engines: {node: '>= 18'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2022,8 +2015,6 @@ snapshots:
   pgpass@1.0.5:
     dependencies:
       split2: 4.2.0
-
-  pgvector@0.2.1: {}
 
   picocolors@1.1.1: {}
 

--- a/aladin-mcp-server/src/db.ts
+++ b/aladin-mcp-server/src/db.ts
@@ -1,4 +1,5 @@
-import { Pool } from 'pg';
+import { Client, Pool } from 'pg';
+import pgvector from 'pgvector/pg';
 
 console.debug('Connecting to PostgreSQL database...');
 
@@ -15,5 +16,26 @@ const pool = new Pool({
 });
 
 console.debug('Connected to PostgreSQL !!');
+
+pool.on('connect', async (client) => {
+  console.debug('Connected to PostgreSQL !!');
+  await pgvector.registerTypes(client);
+});
+
+pool.on('release', (err, client) => {
+  if (err) {
+    console.error('Error releasing PostgreSQL client:', err);
+  } else {
+    console.debug('pool connection released');
+  }
+});
+
+pool.on('acquire', (client) => {
+  console.debug('pool connection acquired');
+});
+
+pool.on('remove', (client) => {
+  console.debug('pool connection removed');
+});
 
 export const db = pool;

--- a/aladin-mcp-server/src/db.ts
+++ b/aladin-mcp-server/src/db.ts
@@ -1,5 +1,7 @@
 import { Pool } from 'pg';
 
+console.debug('Connecting to PostgreSQL database...');
+
 const pool = new Pool({
   user: process.env.DB_USER,
   host: process.env.DB_HOST,
@@ -11,5 +13,7 @@ const pool = new Pool({
   idleTimeoutMillis: 150000,
   connectionTimeoutMillis: 2000,
 });
+
+console.debug('Connected to PostgreSQL !!');
 
 export const db = pool;

--- a/aladin-mcp-server/src/db.ts
+++ b/aladin-mcp-server/src/db.ts
@@ -1,5 +1,4 @@
-import { Client, Pool } from 'pg';
-import pgvector from 'pgvector/pg';
+import { Pool } from 'pg';
 
 console.debug('Connecting to PostgreSQL database...');
 
@@ -19,7 +18,6 @@ console.debug('Connected to PostgreSQL !!');
 
 pool.on('connect', async (client) => {
   console.debug('Connected to PostgreSQL !!');
-  await pgvector.registerTypes(client);
 });
 
 pool.on('release', (err, client) => {

--- a/aladin-mcp-server/src/server.ts
+++ b/aladin-mcp-server/src/server.ts
@@ -11,16 +11,10 @@ export function createServer() {
   });
   const aladin = new Aladin({ ttbKey: process.env.TTB_KEY ?? '' });
 
-  server.tool('get_new_books_by_monthly', async () => {
-    const date = new Date();
-    const year = date.getFullYear();
-    const month = date.getMonth() + 1;
-
+  server.tool('get_new_books', async () => {
     const results = await aladin.listItems({
       queryType: 'ItemNewAll',
       searchTarget: 'Book',
-      year: year,
-      month: month,
       cover: 'Big',
     });
 
@@ -79,16 +73,10 @@ export function createServer() {
     },
   );
 
-  server.tool('get_new_books_special_by_monthly', async () => {
-    const date = new Date();
-    const year = date.getFullYear();
-    const month = date.getMonth() + 1;
-
+  server.tool('get_new_books_special', async () => {
     const results = await aladin.listItems({
       queryType: 'ItemNewSpecial',
       searchTarget: 'Book',
-      year: year,
-      month: month,
       cover: 'Big',
     });
 
@@ -114,7 +102,7 @@ export function createServer() {
     };
   });
 
-  server.tool('get_bestsellers', async () => {
+  server.tool('get_bestsellers_by_latest', async () => {
     const results = await aladin.listItems({
       queryType: 'Bestseller',
       searchTarget: 'Book',

--- a/aladin-mcp-server/src/server.ts
+++ b/aladin-mcp-server/src/server.ts
@@ -9,6 +9,34 @@ export function createServer() {
     version: '1.0.0',
   });
   const aladin = new Aladin({ ttbKey: process.env.TTB_KEY ?? '' });
+
+  server.tool('get_new_books', { cid: z.number() }, async ({ cid }) => {
+    const results = await aladin.listItems({
+      queryType: 'ItemNewAll',
+    });
+
+    if (!results.success) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: results.error.message,
+          },
+        ],
+        isError: true,
+      };
+    }
+    return {
+      content: results.data.item.map((item) => {
+        return {
+          type: 'text',
+          text: JSON.stringify(item),
+          mimeType: 'application/json',
+        };
+      }),
+    };
+  });
+
   server.tool(
     'get_new_books_by_category_id',
     { cid: z.number() },

--- a/aladin-mcp-server/src/server.ts
+++ b/aladin-mcp-server/src/server.ts
@@ -76,6 +76,7 @@ export function createServer() {
     { query: z.string() },
     async ({ query }) => {
       try {
+        // TODO 시멘틱 서치 구현 issue#23
         const result = await db.query(
           `SELECT cid,
 							category,

--- a/aladin-mcp-server/src/server.ts
+++ b/aladin-mcp-server/src/server.ts
@@ -10,7 +10,7 @@ export function createServer() {
   });
   const aladin = new Aladin({ ttbKey: process.env.TTB_KEY ?? '' });
 
-  server.tool('get_new_books_by_month', async () => {
+  server.tool('get_new_books_by_monthly', async () => {
     const date = new Date();
     const year = date.getFullYear();
     const month = date.getMonth() + 1;
@@ -78,7 +78,7 @@ export function createServer() {
     },
   );
 
-  server.tool('get_new_books_special_by_month', async () => {
+  server.tool('get_new_books_special_by_monthly', async () => {
     const date = new Date();
     const year = date.getFullYear();
     const month = date.getMonth() + 1;

--- a/aladin-mcp-server/src/server.ts
+++ b/aladin-mcp-server/src/server.ts
@@ -68,6 +68,61 @@ export function createServer() {
       };
     },
   );
+
+  server.tool('get_new_books_special', { cid: z.number() }, async ({ cid }) => {
+    const results = await aladin.listItems({
+      queryType: 'ItemNewSpecial',
+    });
+
+    if (!results.success) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: results.error.message,
+          },
+        ],
+        isError: true,
+      };
+    }
+    return {
+      content: results.data.item.map((item) => {
+        return {
+          type: 'text',
+          text: JSON.stringify(item),
+          mimeType: 'application/json',
+        };
+      }),
+    };
+  });
+
+  server.tool('get_bestsellers', { cid: z.number() }, async ({ cid }) => {
+    const results = await aladin.listItems({
+      queryType: 'Bestseller',
+    });
+
+    if (!results.success) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: results.error.message,
+          },
+        ],
+        isError: true,
+      };
+    }
+    return {
+      content: results.data.item.map((item) => {
+        return {
+          type: 'text',
+          text: JSON.stringify(item),
+          mimeType: 'application/json',
+        };
+      }),
+    };
+  });
+
   server.tool(
     'get_bestsellers_by_category_id',
     { cid: z.number() },

--- a/aladin-mcp-server/src/server.ts
+++ b/aladin-mcp-server/src/server.ts
@@ -185,7 +185,7 @@ export function createServer() {
         const vectorLiteral = `[${embeddedQuery.join(',')}]`;
         const result = await db.query(
           `
-            SELECT cid, category, mall, depth1, depth2, depth3, depth4, depth5, cosine_similarity
+            SELECT cid, category, mall, depth1, depth2, depth3, depth4, depth5
             FROM (
                 SELECT cid, category, mall, depth1, depth2, depth3, depth4, depth5,
                         1 - (category_vector <=> $1) AS cosine_similarity

--- a/aladin-mcp-server/src/server.ts
+++ b/aladin-mcp-server/src/server.ts
@@ -182,7 +182,6 @@ export function createServer() {
     async ({ query }) => {
       try {
         const embeddedQuery = await createEmbedding(query);
-        const vectorLiteral = `[${embeddedQuery.join(',')}]`;
         const result = await db.query(
           `
             SELECT cid, category, mall, depth1, depth2, depth3, depth4, depth5
@@ -195,7 +194,7 @@ export function createServer() {
             ) AS kgbook
             ORDER BY cosine_similarity DESC;
         `,
-          [vectorLiteral],
+          [JSON.stringify(embeddedQuery)],
         );
         return {
           content: result.rows.map((row) => ({

--- a/aladin-mcp-server/src/server.ts
+++ b/aladin-mcp-server/src/server.ts
@@ -202,5 +202,122 @@ export function createServer() {
       }
     },
   );
+
+  server.tool(
+    'search_books_by_title_and_author',
+    { query: z.string() },
+    async ({ query }) => {
+      const results = await aladin.searchItems({
+        query: query,
+        queryType: 'Keyword',
+      });
+
+      if (!results.success) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: results.error.message,
+            },
+          ],
+          isError: true,
+        };
+      }
+      return {
+        content: results.data.item.map((item) => {
+          return {
+            type: 'text',
+            text: JSON.stringify(item),
+            mimeType: 'application/json',
+          };
+        }),
+      };
+    },
+  );
+
+  server.tool('get_book_by_item_id', { id: z.number() }, async ({ id }) => {
+    const results = await aladin.lookupItem({
+      itemId: id,
+      itemIdType: 'ItemId',
+    });
+
+    if (!results.success) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: results.error.message,
+          },
+        ],
+        isError: true,
+      };
+    }
+    return {
+      content: results.data.item.map((item) => {
+        return {
+          type: 'text',
+          text: JSON.stringify(item),
+          mimeType: 'application/json',
+        };
+      }),
+    };
+  });
+
+  server.tool('get_book_by_isbn', { id: z.number() }, async ({ id }) => {
+    const results = await aladin.lookupItem({
+      itemId: id,
+      itemIdType: 'ISBN',
+    });
+
+    if (!results.success) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: results.error.message,
+          },
+        ],
+        isError: true,
+      };
+    }
+    return {
+      content: results.data.item.map((item) => {
+        return {
+          type: 'text',
+          text: JSON.stringify(item),
+          mimeType: 'application/json',
+        };
+      }),
+    };
+  });
+
+  server.tool('get_book_by_isbn13', { id: z.number() }, async ({ id }) => {
+    const results = await aladin.lookupItem({
+      itemId: id,
+      itemIdType: 'ISBN13',
+    });
+
+    if (!results.success) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: results.error.message,
+          },
+        ],
+        isError: true,
+      };
+    }
+    return {
+      content: results.data.item.map((item) => {
+        return {
+          type: 'text',
+          text: JSON.stringify(item),
+          mimeType: 'application/json',
+        };
+      }),
+    };
+  });
+
   return server;
 }

--- a/aladin-mcp-server/src/server.ts
+++ b/aladin-mcp-server/src/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { Aladin } from 'aladin-client';
 import { z } from 'zod';
 import { db } from './db';
+import { createEmbedding } from './service/openAiService';
 
 export function createServer() {
   const server = new McpServer({
@@ -180,24 +181,21 @@ export function createServer() {
     { query: z.string() },
     async ({ query }) => {
       try {
-        // TODO 시멘틱 서치 구현 issue#23
+        const embeddedQuery = await createEmbedding(query);
+        const vectorLiteral = `[${embeddedQuery.join(',')}]`;
         const result = await db.query(
-          `SELECT cid,
-							category,
-							mall,
-							depth1,
-							depth2,
-							depth3,
-							depth4,
-							depth5
-					 FROM kgbook.public.category
-					 WHERE category LIKE $1::text
-						OR depth1 LIKE $1::text
-						OR depth2 LIKE $1::text
-						OR depth3 LIKE $1::text
-						OR depth4 LIKE $1::text
-						OR depth5 LIKE $1::text`,
-          [`%${query}%`],
+          `
+            SELECT cid, category, mall, depth1, depth2, depth3, depth4, depth5, cosine_similarity
+            FROM (
+                SELECT cid, category, mall, depth1, depth2, depth3, depth4, depth5,
+                        1 - (category_vector <=> $1) AS cosine_similarity
+                FROM kgbook.public.category
+                ORDER BY cosine_similarity DESC
+                LIMIT 1000 -- TODO 몇 건까지 제한을 할지 논의 필요?!
+            ) AS kgbook
+            ORDER BY cosine_similarity DESC;
+        `,
+          [vectorLiteral],
         );
         return {
           content: result.rows.map((row) => ({

--- a/aladin-mcp-server/src/server.ts
+++ b/aladin-mcp-server/src/server.ts
@@ -178,9 +178,18 @@ export function createServer() {
 
   server.tool(
     'search_book_categories',
-    { query: z.string() },
-    async ({ query }) => {
+    {
+      query: z.string(),
+      page: z.number().optional(),
+      size: z.number().optional(),
+    },
+    async ({ query, page = 1, size = 20 }) => {
       try {
+        const sortField = 'category_vector';
+        const sortOrder = 'desc';
+
+        const offset = (page - 1) * size;
+
         const embeddedQuery = await createEmbedding(query);
         const result = await db.query(
           `
@@ -189,12 +198,11 @@ export function createServer() {
                 SELECT cid, category, mall, depth1, depth2, depth3, depth4, depth5,
                         1 - (category_vector <=> $1) AS cosine_similarity
                 FROM kgbook.public.category
-                ORDER BY cosine_similarity DESC
-                LIMIT 1000 -- TODO 몇 건까지 제한을 할지 논의 필요?!
+                ORDER BY ${sortField} ${sortOrder}
+                LIMIT $2 OFFSET $3
             ) AS kgbook
-            ORDER BY cosine_similarity DESC;
         `,
-          [JSON.stringify(embeddedQuery)],
+          [JSON.stringify(embeddedQuery), size, offset],
         );
         return {
           content: result.rows.map((row) => ({

--- a/aladin-mcp-server/src/server.ts
+++ b/aladin-mcp-server/src/server.ts
@@ -10,9 +10,17 @@ export function createServer() {
   });
   const aladin = new Aladin({ ttbKey: process.env.TTB_KEY ?? '' });
 
-  server.tool('get_new_books', { cid: z.number() }, async ({ cid }) => {
+  server.tool('get_new_books_by_month', async () => {
+    const date = new Date();
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+
     const results = await aladin.listItems({
       queryType: 'ItemNewAll',
+      searchTarget: 'Book',
+      year: year,
+      month: month,
+      cover: 'Big',
     });
 
     if (!results.success) {
@@ -44,6 +52,7 @@ export function createServer() {
       const results = await aladin.listItems({
         queryType: 'ItemNewAll',
         categoryId: cid,
+        cover: 'Big',
       });
 
       if (!results.success) {
@@ -69,9 +78,17 @@ export function createServer() {
     },
   );
 
-  server.tool('get_new_books_special', { cid: z.number() }, async ({ cid }) => {
+  server.tool('get_new_books_special_by_month', async () => {
+    const date = new Date();
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+
     const results = await aladin.listItems({
       queryType: 'ItemNewSpecial',
+      searchTarget: 'Book',
+      year: year,
+      month: month,
+      cover: 'Big',
     });
 
     if (!results.success) {
@@ -96,9 +113,11 @@ export function createServer() {
     };
   });
 
-  server.tool('get_bestsellers', { cid: z.number() }, async ({ cid }) => {
+  server.tool('get_bestsellers', async () => {
     const results = await aladin.listItems({
       queryType: 'Bestseller',
+      searchTarget: 'Book',
+      cover: 'Big',
     });
 
     if (!results.success) {
@@ -130,6 +149,7 @@ export function createServer() {
       const results = await aladin.listItems({
         queryType: 'Bestseller',
         categoryId: cid,
+        cover: 'Big',
       });
 
       if (!results.success) {
@@ -154,6 +174,7 @@ export function createServer() {
       };
     },
   );
+
   server.tool(
     'search_book_categories',
     { query: z.string() },
@@ -186,6 +207,7 @@ export function createServer() {
           })),
         };
       } catch (err: unknown) {
+        console.error(err);
         const message =
           err && typeof err === 'object' && 'message' in err
             ? err.message
@@ -210,6 +232,7 @@ export function createServer() {
       const results = await aladin.searchItems({
         query: query,
         queryType: 'Keyword',
+        cover: 'Big',
       });
 
       if (!results.success) {
@@ -239,6 +262,7 @@ export function createServer() {
     const results = await aladin.lookupItem({
       itemId: id,
       itemIdType: 'ItemId',
+      cover: 'Big',
     });
 
     if (!results.success) {
@@ -263,38 +287,9 @@ export function createServer() {
     };
   });
 
-  server.tool('get_book_by_isbn', { id: z.number() }, async ({ id }) => {
+  server.tool('get_book_by_isbn', { isbn: z.string() }, async ({ isbn }) => {
     const results = await aladin.lookupItem({
-      itemId: id,
-      itemIdType: 'ISBN',
-    });
-
-    if (!results.success) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text: results.error.message,
-          },
-        ],
-        isError: true,
-      };
-    }
-    return {
-      content: results.data.item.map((item) => {
-        return {
-          type: 'text',
-          text: JSON.stringify(item),
-          mimeType: 'application/json',
-        };
-      }),
-    };
-  });
-
-  server.tool('get_book_by_isbn13', { id: z.number() }, async ({ id }) => {
-    const results = await aladin.lookupItem({
-      itemId: id,
-      itemIdType: 'ISBN13',
+      itemId: isbn,
     });
 
     if (!results.success) {

--- a/aladin-mcp-server/src/service/openAiService.ts
+++ b/aladin-mcp-server/src/service/openAiService.ts
@@ -1,0 +1,41 @@
+// OpenAI 임베딩 응답 구조 정의
+interface OpenAiEmbeddingData {
+  object: string;
+  index: number;
+  embedding: number[];
+}
+
+interface OpenAiUsage {
+  prompt_tokens: number;
+  total_tokens: number;
+}
+
+interface OpenAiEmbeddingResponse {
+  data: OpenAiEmbeddingData[];
+  object: string;
+  model: string;
+  usage: OpenAiUsage;
+}
+
+export async function createEmbedding(text: string): Promise<number[]> {
+  try {
+    const res = await fetch('https://api.openai.com/v1/embeddings', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'text-embedding-3-small',
+        input: text,
+      }),
+    });
+
+    const json = (await res.json()) as OpenAiEmbeddingResponse;
+    return json.data[0].embedding;
+  } catch (err) {
+    console.error(err);
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Error creating embedding: ${message}`);
+  }
+}


### PR DESCRIPTION
## 변경사항

- mcp 툴 구현
- 알라딘 클라이언트에 있는 api 명세서 보고 필요해보이는 것들 추가해두었습니다. 더 있을까요 ?? 
   - cover 는 big 정돈 해줘야 화질이 좋아서 big 으로 보내도록 했습니다.
- 시멘틱 서치 구현
   - 기존에 있는 카테고리 검색하는 툴을 시멘틱 서치로 변경하였습니다.
   - langchain 이 붙으면 임베딩 부분이 api 쪽으로 변경될 수도 있을 것 같은데 우선 구현만 해두었습니다. 

## 참고사항

- 저스틴이 aladinClient 너무 잘 만들어두셔서 저는 그저 추가만 했네요 .... 
- 그래서 모듈화를 해보려고 하는데 타입 지옥에 갇혀있습니다 ...... (아직 진행중............)

## 관련 이슈

Closes #12
Closes #23 
